### PR TITLE
Bump sentry to 5.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.version>2.7.4.Final</quarkus.version>
 
-        <sentry.version>5.6.3</sentry.version>
+        <sentry.version>5.7.3</sentry.version>
         <assertj.version>3.22.0</assertj.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
Sentry prints a message in its UI to use v5.7.3

`We recommend you [update your SDK from sentry.java@v5.6.3 to sentry.java@v5.7.3](https://docs.sentry.io/platforms/java?_ga=2.43173093.1985676975.1651478418-151758781.1650636946) (All sentry packages should be updated and their versions should match)`

This PR does the bump.