### PR TITLE
Add capability to configure the Sentry Proxy

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-logging-sentry.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-logging-sentry.adoc
@@ -188,4 +188,84 @@ endif::add-copy-button-to-env-var[]
 --|double 
 |
 
+
+a| [[quarkus-logging-sentry_quarkus.log.sentry.proxy-enabled]]`link:#quarkus-logging-sentry_quarkus.log.sentry.proxy-enabled[quarkus.log.sentry.proxy-enabled]`
+
+[.description]
+--
+When set to `true`, a proxy can be configured that should be used for outbound requests. This is also used for HTTPS requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_SENTRY_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-logging-sentry_quarkus.log.sentry.proxy-host]]`link:#quarkus-logging-sentry_quarkus.log.sentry.proxy-host[quarkus.log.sentry.proxy-host]`
+
+[.description]
+--
+Sets the host name of the proxy server
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY_PROXY_HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_SENTRY_PROXY_HOST+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-logging-sentry_quarkus.log.sentry.proxy-port]]`link:#quarkus-logging-sentry_quarkus.log.sentry.proxy-port[quarkus.log.sentry.proxy-port]`
+
+[.description]
+--
+Sets the port number of the proxy server
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY_PROXY_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_SENTRY_PROXY_PORT+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|
+
+
+a| [[quarkus-logging-sentry_quarkus.log.sentry.proxy-username]]`link:#quarkus-logging-sentry_quarkus.log.sentry.proxy-username[quarkus.log.sentry.proxy-username]`
+
+[.description]
+--
+Sets the username to authenticate on the proxy server
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_SENTRY_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-logging-sentry_quarkus.log.sentry.proxy-password]]`link:#quarkus-logging-sentry_quarkus.log.sentry.proxy-password[quarkus.log.sentry.proxy-password]`
+
+[.description]
+--
+Sets the password to authenticate on the proxy server
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_SENTRY_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
 |===

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
@@ -119,4 +119,35 @@ public class SentryConfig {
      */
     @ConfigItem
     public OptionalDouble tracesSampleRate;
+
+    /**
+     * When set to {@code true}, a proxy can be configured that should be used for outbound requests. This is also
+     * used for HTTPS requests.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean proxyEnabled;
+
+    /**
+     * Sets the host name of the proxy server
+     */
+    @ConfigItem
+    public Optional<String> proxyHost;
+
+    /**
+     * Sets the port number of the proxy server
+     */
+    @ConfigItem
+    public Optional<Integer> proxyPort;
+
+    /**
+     * Sets the username to authenticate on the proxy server
+     */
+    @ConfigItem
+    public Optional<String> proxyUsername;
+
+    /**
+     * Sets the password to authenticate on the proxy server
+     */
+    @ConfigItem
+    public Optional<String> proxyPassword;
 }

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
@@ -1,5 +1,7 @@
 package io.quarkus.logging.sentry;
 
+import static java.util.function.Predicate.not;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -56,6 +58,20 @@ public class SentryHandlerValueFactory {
         sentryConfig.release.ifPresent(options::setRelease);
         sentryConfig.serverName.ifPresent(options::setServerName);
         sentryConfig.tracesSampleRate.ifPresent(options::setTracesSampleRate);
+
+        if (sentryConfig.proxyEnabled) {
+            if (sentryConfig.proxyHost.filter(not(String::isBlank)).isPresent()) {
+                LOG.trace("Proxy is enabled for Sentry's outgoing requests");
+                options.setProxy(new SentryOptions.Proxy(
+                        sentryConfig.proxyHost.get(),
+                        sentryConfig.proxyPort.map(String::valueOf).orElse(null),
+                        sentryConfig.proxyUsername.orElse(null),
+                        sentryConfig.proxyPassword.orElse(null)));
+            } else {
+                LOG.warn("Proxy is enabled for Sentry but no host is provided. Ignoring Proxy configuration.");
+            }
+        }
+
         options.setDebug(sentryConfig.debug);
         return options;
     }


### PR DESCRIPTION
Quarkus and Java have some options to allow an application to make outgoing HTTP requests through a Proxy.
However, for security or organizational reasons, we sometimes need to configure only Sentry to do so.

This merge requests enables 4 properties that are added to the Sentry.Proxy options.