### PR TITLE
feat: enable Sentry.BeforeSendCallback injection

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -74,6 +74,24 @@ quarkus.log.sentry.level=ERROR
 quarkus.log.sentry.in-app-packages=org.example
 ----
 
+== BeforeSend callbacks
+
+Sentry events can be customised before transmission using Sentry's builtin `BeforeSendCallback` interface.
+Any application-scoped bean marked with the interface will be called. This can be used to add data to the event as well as completely suppressing the event.
+Make sure to mark beans as unremovable.
+
+[source, Java]
+----
+@ApplicationScoped
+@Unremovable
+public class SentryCallbackHandler implements SentryOptions.BeforeSendCallback {
+    @Override
+    public SentryEvent execute(SentryEvent sentryEvent, Hint hint) {
+        return sentryEvent; // event unchanged
+    }
+}
+----
+
 == Configuration Reference
 
 This extension is configured through the standard `application.properties` file.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -28,6 +28,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/integration-tests/src/main/java/io/quarkiverse/loggingsentry/it/LoggingSentryResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/loggingsentry/it/LoggingSentryResource.java
@@ -1,12 +1,15 @@
 package io.quarkiverse.loggingsentry.it;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
 @Path("/logging-sentry")
 @ApplicationScoped
 public class LoggingSentryResource {
+    @Inject
+    SentryCallbackHandler sentryCallbackHandler;
 
     @GET
     public String hello() {
@@ -18,4 +21,11 @@ public class LoggingSentryResource {
     public String nope() {
         throw new RuntimeException("broken");
     }
+
+    @GET
+    @Path("/get-callback-handler-status")
+    public String getCallbackHandlerStatus() {
+        return sentryCallbackHandler.wasCalledWithRuntimeException().toString();
+    }
+
 }

--- a/integration-tests/src/main/java/io/quarkiverse/loggingsentry/it/LoggingSentryResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/loggingsentry/it/LoggingSentryResource.java
@@ -12,4 +12,10 @@ public class LoggingSentryResource {
     public String hello() {
         return "Hello logging-sentry";
     }
+
+    @GET
+    @Path("/broken")
+    public String nope() {
+        throw new RuntimeException("broken");
+    }
 }

--- a/integration-tests/src/main/java/io/quarkiverse/loggingsentry/it/SentryCallbackHandler.java
+++ b/integration-tests/src/main/java/io/quarkiverse/loggingsentry/it/SentryCallbackHandler.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.loggingsentry.it;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.sentry.Hint;
+import io.sentry.SentryEvent;
+import io.sentry.SentryOptions;
+
+@ApplicationScoped
+@Unremovable
+public class SentryCallbackHandler implements SentryOptions.BeforeSendCallback {
+    private Boolean wasCalled = false;
+
+    @Override
+    public SentryEvent execute(SentryEvent sentryEvent, Hint hint) {
+        if (sentryEvent.getExceptions().get(0).getType().equals(RuntimeException.class.getSimpleName())) {
+            wasCalled = true;
+        }
+        return null;
+    }
+
+    public Boolean wasCalledWithRuntimeException() {
+        return wasCalled;
+    }
+}

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.log.sentry=true
+quarkus.log.sentry.dsn=https://123@default.com/22222
+quarkus.log.sentry.in-app-packages=*

--- a/integration-tests/src/test/java/io/quarkiverse/loggingsentry/it/LoggingSentryResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/loggingsentry/it/LoggingSentryResourceTest.java
@@ -1,10 +1,7 @@
 package io.quarkiverse.loggingsentry.it;
 
 import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
-
-import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,9 +9,6 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class LoggingSentryResourceTest {
-    @Inject
-    SentryCallbackHandler sentryCallbackHandler;
-
     @Test
     public void testHelloEndpoint() {
         given()
@@ -26,11 +20,21 @@ public class LoggingSentryResourceTest {
 
     @Test
     public void testBeforeSendCallback() {
+        assertCallbackHandlerCallStatus(false);
+
         given()
                 .when().get("/logging-sentry/broken")
                 .then()
                 .statusCode(500);
 
-        assertThat(sentryCallbackHandler.wasCalledWithRuntimeException()).isTrue();
+        assertCallbackHandlerCallStatus(true);
+    }
+
+    private static void assertCallbackHandlerCallStatus(Boolean wasCalled) {
+        given()
+                .when().get("/logging-sentry/get-callback-handler-status")
+                .then()
+                .statusCode(200)
+                .body(is(wasCalled.toString()));
     }
 }

--- a/integration-tests/src/test/java/io/quarkiverse/loggingsentry/it/LoggingSentryResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/loggingsentry/it/LoggingSentryResourceTest.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.loggingsentry.it;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
+
+import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +12,8 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class LoggingSentryResourceTest {
+    @Inject
+    SentryCallbackHandler sentryCallbackHandler;
 
     @Test
     public void testHelloEndpoint() {
@@ -17,5 +22,15 @@ public class LoggingSentryResourceTest {
                 .then()
                 .statusCode(200)
                 .body(is("Hello logging-sentry"));
+    }
+
+    @Test
+    public void testBeforeSendCallback() {
+        given()
+                .when().get("/logging-sentry/broken")
+                .then()
+                .statusCode(500);
+
+        assertThat(sentryCallbackHandler.wasCalledWithRuntimeException()).isTrue();
     }
 }

--- a/integration-tests/src/test/java/io/quarkiverse/loggingsentry/it/SentryBeforeSendCallbacksHandlerTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/loggingsentry/it/SentryBeforeSendCallbacksHandlerTest.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.loggingsentry.it;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.logging.sentry.SentryBeforeSendCallbacksHandler;
+import io.quarkus.test.junit.QuarkusTest;
+import io.sentry.Hint;
+import io.sentry.SentryEvent;
+import io.sentry.protocol.SentryException;
+
+@QuarkusTest
+public class SentryBeforeSendCallbacksHandlerTest {
+
+    @Test
+    public void testBeforeSendCallbackCanSetEventToNull() {
+        SentryBeforeSendCallbacksHandler sut = new SentryBeforeSendCallbacksHandler();
+        SentryEvent testEvent = new SentryEvent();
+        SentryException testException = new SentryException();
+        testException.setType("Foo");
+        testEvent.setExceptions(
+                List.of(testException));
+
+        assertThat(
+                sut.executeCallbacks(testEvent, new Hint())).isNull();
+    }
+
+    @Test
+    public void testBeforeSendCallbackCanBeCalledWithNull() {
+        // given
+        SentryBeforeSendCallbacksHandler sut = new SentryBeforeSendCallbacksHandler();
+
+        assertThat(
+                sut.executeCallbacks(null, new Hint())).isNull();
+    }
+}

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryBeforeSendCallbacksHandler.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryBeforeSendCallbacksHandler.java
@@ -10,8 +10,12 @@ import io.sentry.SentryOptions.BeforeSendCallback;
  * Executes beans marked with BeforeSend callback interface.
  */
 public class SentryBeforeSendCallbacksHandler {
-    public void executeCallbacks(SentryEvent sentryEvent, Hint hint) {
-        CDI.current().select(BeforeSendCallback.class)
-                .forEach(beforeSendCallback -> beforeSendCallback.execute(sentryEvent, hint));
+    public SentryEvent executeCallbacks(SentryEvent sentryEvent, Hint hint) {
+        if (sentryEvent != null) {
+            for (BeforeSendCallback callback : CDI.current().select(BeforeSendCallback.class)) {
+                sentryEvent = callback.execute(sentryEvent, hint);
+            }
+        }
+        return sentryEvent;
     }
 }

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryBeforeSendCallbacksHandler.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryBeforeSendCallbacksHandler.java
@@ -1,0 +1,17 @@
+package io.quarkus.logging.sentry;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import io.sentry.Hint;
+import io.sentry.SentryEvent;
+import io.sentry.SentryOptions.BeforeSendCallback;
+
+/**
+ * Executes beans marked with BeforeSend callback interface.
+ */
+public class SentryBeforeSendCallbacksHandler {
+    public void executeCallbacks(SentryEvent sentryEvent, Hint hint) {
+        CDI.current().select(BeforeSendCallback.class)
+                .forEach(beforeSendCallback -> beforeSendCallback.execute(sentryEvent, hint));
+    }
+}

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
@@ -62,10 +62,7 @@ public class SentryHandlerValueFactory {
         sentryConfig.tracesSampleRate.ifPresent(options::setTracesSampleRate);
 
         if (beforeSendCallbacksHandler != null) {
-            options.setBeforeSend((sentryEvent, hint) -> {
-                beforeSendCallbacksHandler.executeCallbacks(sentryEvent, hint);
-                return sentryEvent;
-            });
+            options.setBeforeSend((sentryEvent, hint) -> beforeSendCallbacksHandler.executeCallbacks(sentryEvent, hint));
         }
 
         if (sentryConfig.proxy.enable) {

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
@@ -81,7 +81,6 @@ public class SentryHandlerValueFactory {
             }
         }
 
-
         options.setDebug(sentryConfig.debug);
         return options;
     }

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
@@ -18,14 +18,15 @@ import io.sentry.jul.SentryHandler;
 public class SentryHandlerValueFactory {
     private static final Logger LOG = Logger.getLogger(SentryHandlerValueFactory.class);
 
-    public RuntimeValue<Optional<Handler>> create(final SentryConfig config) {
+    public RuntimeValue<Optional<Handler>> create(final SentryConfig config,
+            final SentryBeforeSendCallbacksHandler beforeSendCallbacksHandler) {
 
         if (!config.enable) {
             return new RuntimeValue<>(Optional.empty());
         }
 
         // Init Sentry
-        final SentryOptions options = toSentryOptions(config);
+        final SentryOptions options = toSentryOptions(config, beforeSendCallbacksHandler);
         Sentry.init(options);
         SentryHandler handler = new SentryHandler(options);
         handler.setLevel(config.level);
@@ -35,7 +36,8 @@ public class SentryHandlerValueFactory {
         return new RuntimeValue<>(Optional.of(handler));
     }
 
-    public static SentryOptions toSentryOptions(SentryConfig sentryConfig) {
+    public static SentryOptions toSentryOptions(SentryConfig sentryConfig,
+            SentryBeforeSendCallbacksHandler beforeSendCallbacksHandler) {
         if (!sentryConfig.dsn.isPresent()) {
             throw new ConfigurationException(
                     "Configuration key \"quarkus.log.sentry.dsn\" is required when Sentry is enabled, but its value is empty/missing");
@@ -56,6 +58,13 @@ public class SentryHandlerValueFactory {
         sentryConfig.release.ifPresent(options::setRelease);
         sentryConfig.serverName.ifPresent(options::setServerName);
         sentryConfig.tracesSampleRate.ifPresent(options::setTracesSampleRate);
+
+        if (beforeSendCallbacksHandler != null) {
+            options.setBeforeSend((sentryEvent, hint) -> {
+                beforeSendCallbacksHandler.executeCallbacks(sentryEvent, hint);
+                return sentryEvent;
+            });
+        }
         options.setDebug(sentryConfig.debug);
         return options;
     }


### PR DESCRIPTION
Extends the quarkus-logging-sentry extension with BeforeSendCallback beans which can be injected as `@ApplicationScoped`  beans to customize behavior before events are sent to Sentry API.

Open TODOS:
* community code review 
* extend documentation
