### PR TITLE
Fix buildstep cycle error

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/loggingsentry/it/SentryBeforeSendCallbacksHandlerTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/loggingsentry/it/SentryBeforeSendCallbacksHandlerTest.java
@@ -4,12 +4,16 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.util.List;
 
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.logging.sentry.SentryBeforeSendCallbacksHandler;
 import io.quarkus.test.junit.QuarkusTest;
 import io.sentry.Hint;
 import io.sentry.SentryEvent;
+import io.sentry.SentryOptions;
 import io.sentry.protocol.SentryException;
 
 @QuarkusTest
@@ -17,7 +21,9 @@ public class SentryBeforeSendCallbacksHandlerTest {
 
     @Test
     public void testBeforeSendCallbackCanSetEventToNull() {
-        SentryBeforeSendCallbacksHandler sut = new SentryBeforeSendCallbacksHandler();
+        final Instance<SentryOptions.BeforeSendCallback> callbacks = CDI.current()
+                .select(SentryOptions.BeforeSendCallback.class);
+        SentryBeforeSendCallbacksHandler sut = new SentryBeforeSendCallbacksHandler(callbacks);
         SentryEvent testEvent = new SentryEvent();
         SentryException testException = new SentryException();
         testException.setType("Foo");
@@ -25,15 +31,17 @@ public class SentryBeforeSendCallbacksHandlerTest {
                 List.of(testException));
 
         assertThat(
-                sut.executeCallbacks(testEvent, new Hint())).isNull();
+                sut.apply(testEvent, new Hint())).isNull();
     }
 
     @Test
     public void testBeforeSendCallbackCanBeCalledWithNull() {
         // given
-        SentryBeforeSendCallbacksHandler sut = new SentryBeforeSendCallbacksHandler();
+        final Instance<SentryOptions.BeforeSendCallback> callbacks = CDI.current()
+                .select(SentryOptions.BeforeSendCallback.class);
+        SentryBeforeSendCallbacksHandler sut = new SentryBeforeSendCallbacksHandler(callbacks);
 
         assertThat(
-                sut.executeCallbacks(null, new Hint())).isNull();
+                sut.apply(null, new Hint())).isNull();
     }
 }

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryBeforeSendCallbacksHandler.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryBeforeSendCallbacksHandler.java
@@ -1,6 +1,8 @@
 package io.quarkus.logging.sentry;
 
-import jakarta.enterprise.inject.spi.CDI;
+import java.util.function.BiFunction;
+
+import jakarta.enterprise.inject.Instance;
 
 import io.sentry.Hint;
 import io.sentry.SentryEvent;
@@ -9,10 +11,17 @@ import io.sentry.SentryOptions.BeforeSendCallback;
 /**
  * Executes beans marked with BeforeSend callback interface.
  */
-public class SentryBeforeSendCallbacksHandler {
-    public SentryEvent executeCallbacks(SentryEvent sentryEvent, Hint hint) {
+public class SentryBeforeSendCallbacksHandler implements BiFunction<SentryEvent, Hint, SentryEvent> {
+    private final Instance<BeforeSendCallback> callbacks;
+
+    public SentryBeforeSendCallbacksHandler(Instance<BeforeSendCallback> callbacks) {
+        this.callbacks = callbacks;
+    }
+
+    @Override
+    public SentryEvent apply(SentryEvent sentryEvent, Hint hint) {
         if (sentryEvent != null) {
-            for (BeforeSendCallback callback : CDI.current().select(BeforeSendCallback.class)) {
+            for (BeforeSendCallback callback : callbacks) {
                 sentryEvent = callback.execute(sentryEvent, hint);
             }
         }


### PR DESCRIPTION
Fixes #161 

As dealing with LogHandler + BeanDetections in the same buildstep seems to create cycles, the detection is now done in the recorder.