### PR TITLE
Add support for context-tags

### DIFF
--- a/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerCustomTest.java
+++ b/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerCustomTest.java
@@ -32,5 +32,6 @@ public class SentryLoggerCustomTest {
         assertThat(sentryHandler).extracting("minimumEventLevel").isEqualTo(Level.INFO);
         assertThat(sentryHandler).extracting("minimumBreadcrumbLevel").isEqualTo(Level.DEBUG);
         assertThat(Sentry.isEnabled()).isTrue();
+        assertThat(options.getContextTags()).containsExactlyInAnyOrder("tag1", "tag2");
     }
 }

--- a/deployment/src/test/resources/application-sentry-logger-custom.properties
+++ b/deployment/src/test/resources/application-sentry-logger-custom.properties
@@ -4,3 +4,4 @@ quarkus.log.sentry.level=TRACE
 quarkus.log.sentry.in-app-packages=io.quarkus.logging.sentry,org.test
 quarkus.log.sentry.minimum-event-level=INFO
 quarkus.log.sentry.minimum-breadcrumb-level=DEBUG
+quarkus.log.sentry.context-tags=tag1,tag2

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
@@ -120,5 +120,13 @@ public class SentryConfig {
     @ConfigItem()
     public OptionalDouble tracesSampleRate;
 
+    /**
+     * Context Tags
+     *
+     * Specifics the MDC tags that are used as Sentry tags
+     */
+    @ConfigItem
+    public Optional<List<String>> contextTags;
+
     public SentryProxyConfig proxy;
 }

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
@@ -61,6 +61,7 @@ public class SentryHandlerValueFactory {
         sentryConfig.release.ifPresent(options::setRelease);
         sentryConfig.serverName.ifPresent(options::setServerName);
         sentryConfig.tracesSampleRate.ifPresent(options::setTracesSampleRate);
+        sentryConfig.contextTags.ifPresent(contextTags -> contextTags.forEach(options::addContextTag));
 
         final Instance<SentryOptions.BeforeSendCallback> select = CDI.current().select(SentryOptions.BeforeSendCallback.class);
         if (!select.isUnsatisfied()) {


### PR DESCRIPTION
Adds support for context-tags which allows to use MDC tags as Sentry tags.

https://docs.sentry.io/platforms/java/guides/jul/usage/advanced-usage/#context-tags