### PR TITLE
Switch configuration to @ConfigMapping

### DIFF
--- a/deployment/src/test/resources/application-sentry-logger-custom.properties
+++ b/deployment/src/test/resources/application-sentry-logger-custom.properties
@@ -1,4 +1,4 @@
-quarkus.log.sentry=true
+quarkus.log.sentry.enabled=true
 quarkus.log.sentry.dsn=https://123@example.com/22222
 quarkus.log.sentry.level=TRACE
 quarkus.log.sentry.in-app-packages=io.quarkus.logging.sentry,org.test

--- a/deployment/src/test/resources/application-sentry-logger-default.properties
+++ b/deployment/src/test/resources/application-sentry-logger-default.properties
@@ -1,3 +1,3 @@
-quarkus.log.sentry=true
+quarkus.log.sentry.enabled=true
 quarkus.log.sentry.dsn=https://123@default.com/22222
 quarkus.log.sentry.in-app-packages=*

--- a/deployment/src/test/resources/application-sentry-logger-environment-option.properties
+++ b/deployment/src/test/resources/application-sentry-logger-environment-option.properties
@@ -1,4 +1,4 @@
-quarkus.log.sentry=true
+quarkus.log.sentry.enabled=true
 quarkus.log.sentry.dsn=https://123@example.com/22222
 quarkus.log.sentry.level=TRACE
 quarkus.log.sentry.in-app-packages=io.quarkus.logging.sentry,org.test

--- a/deployment/src/test/resources/application-sentry-logger-release-option.properties
+++ b/deployment/src/test/resources/application-sentry-logger-release-option.properties
@@ -1,4 +1,4 @@
-quarkus.log.sentry=true
+quarkus.log.sentry.enabled=true
 quarkus.log.sentry.dsn=https://123@example.com/22222
 quarkus.log.sentry.level=TRACE
 quarkus.log.sentry.in-app-packages=io.quarkus.logging.sentry,org.test

--- a/deployment/src/test/resources/application-sentry-logger-traces-sample-rate.properties
+++ b/deployment/src/test/resources/application-sentry-logger-traces-sample-rate.properties
@@ -1,4 +1,4 @@
-quarkus.log.sentry=true
+quarkus.log.sentry.enabled=true
 quarkus.log.sentry.dsn=https://123@default.com/22222
 quarkus.log.sentry.in-app-packages=*
 quarkus.log.sentry.traces-sample-rate=1.0

--- a/deployment/src/test/resources/application-sentry-logger-wrong.properties
+++ b/deployment/src/test/resources/application-sentry-logger-wrong.properties
@@ -1,1 +1,1 @@
-quarkus.log.sentry=true
+quarkus.log.sentry.enabled=true

--- a/docs/modules/ROOT/pages/includes/quarkus-logging-sentry.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-logging-sentry.adoc
@@ -8,7 +8,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a| [[quarkus-logging-sentry_quarkus-log-sentry]] [.property-path]##link:#quarkus-logging-sentry_quarkus-log-sentry[`quarkus.log.sentry`]##
+a| [[quarkus-logging-sentry_quarkus-log-sentry-enabled]] [.property-path]##link:#quarkus-logging-sentry_quarkus-log-sentry-enabled[`quarkus.log.sentry.enabled`]##
 
 [.description]
 --
@@ -16,10 +16,10 @@ Determine whether to enable the Sentry logging extension.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LOG_SENTRY+++`
+Environment variable: `+++QUARKUS_LOG_SENTRY_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
@@ -263,7 +263,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-logging-sentry_quarkus-log-sentry-proxy]] [.property-path]##link:#quarkus-logging-sentry_quarkus-log-sentry-proxy[`quarkus.log.sentry.proxy`]##
+a| [[quarkus-logging-sentry_quarkus-log-sentry-proxy-enabled]] [.property-path]##link:#quarkus-logging-sentry_quarkus-log-sentry-proxy-enabled[`quarkus.log.sentry.proxy.enabled`]##
 
 [.description]
 --
@@ -271,10 +271,10 @@ Determine whether to enable a Proxy for all Sentry outbound requests. This is al
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY_PROXY+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY_PROXY_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LOG_SENTRY_PROXY+++`
+Environment variable: `+++QUARKUS_LOG_SENTRY_PROXY_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/includes/quarkus-logging-sentry_quarkus.log.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-logging-sentry_quarkus.log.adoc
@@ -8,7 +8,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a| [[quarkus-logging-sentry_quarkus-log-sentry]] [.property-path]##link:#quarkus-logging-sentry_quarkus-log-sentry[`quarkus.log.sentry`]##
+a| [[quarkus-logging-sentry_quarkus-log-sentry-enabled]] [.property-path]##link:#quarkus-logging-sentry_quarkus-log-sentry-enabled[`quarkus.log.sentry.enabled`]##
 
 [.description]
 --
@@ -16,10 +16,10 @@ Determine whether to enable the Sentry logging extension.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LOG_SENTRY+++`
+Environment variable: `+++QUARKUS_LOG_SENTRY_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
@@ -263,7 +263,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-logging-sentry_quarkus-log-sentry-proxy]] [.property-path]##link:#quarkus-logging-sentry_quarkus-log-sentry-proxy[`quarkus.log.sentry.proxy`]##
+a| [[quarkus-logging-sentry_quarkus-log-sentry-proxy-enabled]] [.property-path]##link:#quarkus-logging-sentry_quarkus-log-sentry-proxy-enabled[`quarkus.log.sentry.proxy.enabled`]##
 
 [.description]
 --
@@ -271,10 +271,10 @@ Determine whether to enable a Proxy for all Sentry outbound requests. This is al
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY_PROXY+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_SENTRY_PROXY_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LOG_SENTRY_PROXY+++`
+Environment variable: `+++QUARKUS_LOG_SENTRY_PROXY_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -60,7 +60,7 @@ quarkus.log.sentry.in-app-packages=*
 .All errors and warnings occurring in any of the packages will be sent to Sentry with DSN `https://abcd@sentry.io/1234`
 [source, properties]
 ----
-quarkus.log.sentry=true
+quarkus.log.sentry.enabled=true
 quarkus.log.sentry.dsn=https://abcd@sentry.io/1234
 quarkus.log.sentry.in-app-packages=*
 ----
@@ -68,7 +68,7 @@ quarkus.log.sentry.in-app-packages=*
 .All errors occurring in the package `org.example` will be sent to Sentry with DSN `https://abcd@sentry.io/1234`
 [source, properties]
 ----
-quarkus.log.sentry=true
+quarkus.log.sentry.enabled=true
 quarkus.log.sentry.dsn=https://abcd@sentry.io/1234
 quarkus.log.sentry.level=ERROR
 quarkus.log.sentry.in-app-packages=org.example

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.log.sentry=true
+quarkus.log.sentry.enabled=true
 quarkus.log.sentry.dsn=https://123@default.com/22222
 quarkus.log.sentry.in-app-packages=*
 quarkus.log.sentry.tags."test.tag"=testvalue

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -51,9 +51,6 @@
                                     <version>${quarkus.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
@@ -6,21 +6,33 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.logging.Level;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithParentName;
 
 /**
  * Configuration for Sentry logging.
  */
-@ConfigRoot(phase = ConfigPhase.RUN_TIME, name = "log.sentry")
-public class SentryConfig {
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "quarkus.log.sentry")
+public interface SentryConfig {
+
+    /**
+     * Determine whether to enable the Sentry logging extension.
+     *
+     * @deprecated we try to stay away from this pattern now, replace with {@code quarkus.log.sentry.enabled}.
+     */
+    @Deprecated(forRemoval = true)
+    @WithParentName
+    Optional<Boolean> enable();
 
     /**
      * Determine whether to enable the Sentry logging extension.
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    boolean enable;
+    @WithDefault("false")
+    boolean enabled();
 
     /**
      * Sentry DSN
@@ -28,22 +40,21 @@ public class SentryConfig {
      * The DSN is the first and most important thing to configure because it tells the SDK where to send events. You can find
      * your project’s DSN in the “Client Keys” section of your “Project Settings” in Sentry.
      */
-    @ConfigItem
-    public Optional<String> dsn;
+    Optional<String> dsn();
 
     /**
      * The sentry log level.
      */
-    @ConfigItem(defaultValue = "WARN")
-    public Level level;
+    @WithDefault("WARN")
+    Level level();
 
     /**
      * The minimum event level.
      *
      * Every log statement that is greater than minimum event level is turned into Sentry event.
      */
-    @ConfigItem(defaultValue = "WARN")
-    public Level minimumEventLevel;
+    @WithDefault("WARN")
+    Level minimumEventLevel();
 
     /**
      * The minimum breadcrumb level.
@@ -51,8 +62,8 @@ public class SentryConfig {
      * Every log statement that is greater than minimum breadcrumb level is added to Sentry scope as a breadcrumb,
      * which can be later attached to SentryEvent if one is triggered.
      */
-    @ConfigItem(defaultValue = "INFO")
-    public Level minimumBreadcrumbLevel;
+    @WithDefault("INFO")
+    Level minimumBreadcrumbLevel();
 
     /**
      * Sentry differentiates stack frames that are directly related to your application (“in application”) from stack frames
@@ -64,8 +75,7 @@ public class SentryConfig {
      * This option is highly recommended as it affects stacktrace grouping and display on Sentry. See documentation:
      * https://quarkus.io/guides/logging-sentry#in-app-packages
      */
-    @ConfigItem
-    public Optional<List<String>> inAppPackages;
+    Optional<List<String>> inAppPackages();
 
     /**
      * Sentry differentiates stack frames that are directly related to your application (“in application”) from stack frames
@@ -76,8 +86,7 @@ public class SentryConfig {
      *
      * You can configure which package prefixes you want to exclude from logging.
      */
-    @ConfigItem
-    public Optional<List<String>> inAppExcludedPackages;
+    Optional<List<String>> inAppExcludedPackages();
 
     /**
      *
@@ -85,8 +94,7 @@ public class SentryConfig {
      * by adding the names of the exception.(e.g. java.lang.RuntimeException)
      *
      */
-    @ConfigItem
-    public Optional<List<String>> ignoredExceptionsForType;
+    Optional<List<String>> ignoredExceptionsForType();
 
     /**
      * Environment
@@ -100,8 +108,7 @@ public class SentryConfig {
      * -> the environment name cannot contain newlines or spaces, cannot be the string “None” or exceed 64 characters.
      *
      */
-    @ConfigItem
-    public Optional<String> environment;
+    Optional<String> environment();
 
     /**
      * Release
@@ -114,24 +121,22 @@ public class SentryConfig {
      * - Receive email notifications when your code gets deployed
      *
      */
-    @ConfigItem
-    public Optional<String> release;
+    Optional<String> release();
 
     /**
      * Server name
      *
      * Sets the server name that will be sent with each event.
      */
-    @ConfigItem
-    public Optional<String> serverName;
+    Optional<String> serverName();
 
     /**
      * Debug
      *
      * Enables Sentry debug mode.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean debug;
+    @WithDefault("false")
+    boolean debug();
 
     /**
      * This should be a float/double between 0.0 and 1.0 (inclusive) and represents the percentage chance that any given
@@ -139,24 +144,21 @@ public class SentryConfig {
      * So, barring outside influence, 0.0 is a 0% chance (none will be sent) and 1.0 is a 100% chance (all will be sent). This
      * rate applies equally to all transactions.
      */
-    @ConfigItem()
-    public OptionalDouble tracesSampleRate;
+    OptionalDouble tracesSampleRate();
 
     /**
      * Context Tags
      *
      * Specifics the MDC tags that are used as Sentry tags
      */
-    @ConfigItem
-    public Optional<List<String>> contextTags;
+    Optional<List<String>> contextTags();
 
     /**
      * Static tags
      *
      * Static tags that are sent to Sentry with every event.
      */
-    @ConfigItem
-    public Map<String, String> tags;
+    Map<String, String> tags();
 
-    public SentryProxyConfig proxy;
+    SentryProxyConfig proxy();
 }

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
@@ -25,7 +25,7 @@ public class SentryHandlerValueFactory {
 
     public RuntimeValue<Optional<Handler>> create(final SentryConfig config) {
 
-        if (!config.enable) {
+        if (!config.enable().orElse(config.enabled())) {
             return new RuntimeValue<>(Optional.empty());
         }
 
@@ -33,37 +33,37 @@ public class SentryHandlerValueFactory {
         final SentryOptions options = toSentryOptions(config);
         Sentry.init(options);
         SentryHandler handler = new SentryHandler(options);
-        handler.setLevel(config.level);
+        handler.setLevel(config.level());
         handler.setPrintfStyle(true);
-        handler.setMinimumEventLevel(config.minimumEventLevel != null ? config.minimumEventLevel : config.level);
-        handler.setMinimumBreadcrumbLevel(config.minimumBreadcrumbLevel);
+        handler.setMinimumEventLevel(config.minimumEventLevel() != null ? config.minimumEventLevel() : config.level());
+        handler.setMinimumBreadcrumbLevel(config.minimumBreadcrumbLevel());
         return new RuntimeValue<>(Optional.of(handler));
     }
 
     public static SentryOptions toSentryOptions(SentryConfig sentryConfig) {
-        if (!sentryConfig.dsn.isPresent()) {
+        if (!sentryConfig.dsn().isPresent()) {
             throw new ConfigurationException(
                     "Configuration key \"quarkus.log.sentry.dsn\" is required when Sentry is enabled, but its value is empty/missing");
         }
         final SentryOptions options = new SentryOptions();
 
-        if (!sentryConfig.inAppPackages.isPresent()) {
+        if (!sentryConfig.inAppPackages().isPresent()) {
             LOG.warn(
                     "No 'quarkus.log.sentry.in-app-packages' was configured, this option is highly recommended as it affects stacktrace grouping and display on Sentry. See https://quarkus.io/guides/logging-sentry#in-app-packages");
         } else {
-            List<String> inAppPackages = sentryConfig.inAppPackages.get();
+            List<String> inAppPackages = sentryConfig.inAppPackages().get();
             if (inAppPackages.size() != 1 || !Objects.equals(inAppPackages.get(0), "*")) {
                 inAppPackages.forEach(options::addInAppInclude);
             }
         }
 
-        if (sentryConfig.inAppExcludedPackages.isPresent()) {
-            List<String> inAppExcludedPackages = sentryConfig.inAppExcludedPackages.get();
+        if (sentryConfig.inAppExcludedPackages().isPresent()) {
+            List<String> inAppExcludedPackages = sentryConfig.inAppExcludedPackages().get();
             inAppExcludedPackages.forEach(options::addInAppExclude);
         }
 
-        if (sentryConfig.ignoredExceptionsForType.isPresent()) {
-            List<String> ignoredExceptionsForType = sentryConfig.ignoredExceptionsForType.get();
+        if (sentryConfig.ignoredExceptionsForType().isPresent()) {
+            List<String> ignoredExceptionsForType = sentryConfig.ignoredExceptionsForType().get();
             ignoredExceptionsForType.forEach(exceptionTypeName -> {
                 try {
                     Class<? extends Throwable> exceptionClass = Class.forName(exceptionTypeName).asSubclass(Throwable.class);
@@ -76,13 +76,13 @@ public class SentryHandlerValueFactory {
             });
         }
 
-        options.setDsn(sentryConfig.dsn.get());
-        sentryConfig.environment.ifPresent(options::setEnvironment);
-        sentryConfig.release.ifPresent(options::setRelease);
-        sentryConfig.serverName.ifPresent(options::setServerName);
-        sentryConfig.tracesSampleRate.ifPresent(options::setTracesSampleRate);
-        sentryConfig.contextTags.ifPresent(contextTags -> contextTags.forEach(options::addContextTag));
-        sentryConfig.tags.forEach(options::setTag);
+        options.setDsn(sentryConfig.dsn().get());
+        sentryConfig.environment().ifPresent(options::setEnvironment);
+        sentryConfig.release().ifPresent(options::setRelease);
+        sentryConfig.serverName().ifPresent(options::setServerName);
+        sentryConfig.tracesSampleRate().ifPresent(options::setTracesSampleRate);
+        sentryConfig.contextTags().ifPresent(contextTags -> contextTags.forEach(options::addContextTag));
+        sentryConfig.tags().forEach(options::setTag);
 
         final Instance<SentryOptions.BeforeSendCallback> select = CDI.current().select(SentryOptions.BeforeSendCallback.class);
         if (!select.isUnsatisfied()) {
@@ -90,20 +90,20 @@ public class SentryHandlerValueFactory {
             options.setBeforeSend(handler::apply);
         }
 
-        if (sentryConfig.proxy.enable) {
-            if (sentryConfig.proxy.host.filter(not(String::isBlank)).isPresent()) {
+        if (sentryConfig.proxy().enable().orElse(sentryConfig.proxy().enabled())) {
+            if (sentryConfig.proxy().host().filter(not(String::isBlank)).isPresent()) {
                 LOG.trace("Proxy is enabled for Sentry's outgoing requests");
                 options.setProxy(new SentryOptions.Proxy(
-                        sentryConfig.proxy.host.get(),
-                        sentryConfig.proxy.port.map(String::valueOf).orElse(null),
-                        sentryConfig.proxy.username.orElse(null),
-                        sentryConfig.proxy.password.orElse(null)));
+                        sentryConfig.proxy().host().get(),
+                        sentryConfig.proxy().port().map(String::valueOf).orElse(null),
+                        sentryConfig.proxy().username().orElse(null),
+                        sentryConfig.proxy().password().orElse(null)));
             } else {
                 LOG.warn("Proxy is enabled for Sentry but no host is provided. Ignoring Proxy configuration.");
             }
         }
 
-        options.setDebug(sentryConfig.debug);
+        options.setDebug(sentryConfig.debug());
         return options;
     }
 }

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryProxyConfig.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryProxyConfig.java
@@ -3,38 +3,46 @@ package io.quarkus.logging.sentry;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithParentName;
 
 @ConfigGroup
-public class SentryProxyConfig {
+public interface SentryProxyConfig {
+
+    /**
+     * Determine whether to enable a Proxy for all Sentry outbound requests. This is also used for HTTPS
+     * requests.
+     *
+     * @deprecated we try to stay away from this pattern now, replace with {@code quarkus.log.sentry.enabled}.
+     */
+    @Deprecated(forRemoval = true)
+    @WithParentName
+    Optional<Boolean> enable();
+
     /**
      * Determine whether to enable a Proxy for all Sentry outbound requests. This is also used for HTTPS
      * requests.
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public boolean enable;
+    @WithDefault("false")
+    boolean enabled();
 
     /**
      * Sets the host name of the proxy server.
      */
-    @ConfigItem
-    public Optional<String> host;
+    public Optional<String> host();
 
     /**
      * Sets the port number of the proxy server
      */
-    @ConfigItem
-    public Optional<Integer> port;
+    public Optional<Integer> port();
 
     /**
      * Sets the username to authenticate on the proxy server
      */
-    @ConfigItem
-    public Optional<String> username;
+    public Optional<String> username();
 
     /**
      * Sets the password to authenticate on the proxy server
      */
-    @ConfigItem
-    public Optional<String> password;
+    public Optional<String> password();
 }


### PR DESCRIPTION
We plan to retire the legacy config classes at some point in the future so let's move to @ConfigMapping.

Note: I also renamed quarkus.log.sentry to quarkus.log.sentry.enabled as the former is quite painful with YAML configuration. I kept quarkus.log.sentry as deprecated and there's a compatibility layer to avoid breaking older applications.