### PR TITLE
Adds SentryHttpAnnotation to every @Path and starts a simple Tracing call 

### DIFF
--- a/deployment/src/main/java/io/quarkus/logging/sentry/deployment/SentryProcessor.java
+++ b/deployment/src/main/java/io/quarkus/logging/sentry/deployment/SentryProcessor.java
@@ -1,5 +1,13 @@
 package io.quarkus.logging.sentry.deployment;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTransformation;
+import org.jboss.jandex.DotName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
@@ -8,6 +16,8 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LogHandlerBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.logging.sentry.SentryHandlerValueFactory;
+import io.quarkus.logging.sentry.SentryInterceptor;
+import io.quarkus.logging.sentry.SentryHttp;
 import io.sentry.Breadcrumb;
 import io.sentry.SentryBaseEvent;
 import io.sentry.SentryEvent;
@@ -20,6 +30,7 @@ import io.sentry.protocol.*;
 class SentryProcessor {
 
     private static final String FEATURE = "logging-sentry";
+    private static final Logger log = LoggerFactory.getLogger(SentryProcessor.class);
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -35,6 +46,28 @@ class SentryProcessor {
     @BuildStep
     ExtensionSslNativeSupportBuildItem activateSslNativeSupport() {
         return new ExtensionSslNativeSupportBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    AnnotationsTransformerBuildItem registerInterceptors() {
+        DotName path = DotName.createSimple("jakarta.ws.rs.Path");
+
+        return new AnnotationsTransformerBuildItem(AnnotationTransformation.forClasses()
+                .when(transformationContext -> transformationContext
+                        .hasAnnotation(DotName.createSimple("jakarta.ws.rs.Path")))
+                .transform(
+                        transformationContext -> {
+                            String string = transformationContext.declaration().asClass().annotation(path).value()
+                                    .asString();
+                            transformationContext.add(
+                                    AnnotationInstance.builder(SentryHttp.class)
+                                            .value(string).build());
+                        }));
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem loggingInterceptor() {
+        return AdditionalBeanBuildItem.unremovableOf(SentryInterceptor.class);
     }
 
     @BuildStep

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -20,6 +20,10 @@
             <groupId>io.sentry</groupId>
             <artifactId>sentry-jul</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryHttp.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryHttp.java
@@ -1,0 +1,15 @@
+package io.quarkus.logging.sentry;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Retention(RUNTIME)
+@Target({ ElementType.TYPE })
+public @interface SentryHttp {
+}

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryInterceptor.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryInterceptor.java
@@ -1,0 +1,30 @@
+package io.quarkus.logging.sentry;
+
+import io.quarkus.logging.Log;
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import io.sentry.ITransaction;
+import io.sentry.Sentry;
+import io.vertx.core.http.HttpServerRequest;
+
+@SentryHttp()
+@Interceptor
+@Priority(Interceptor.Priority.APPLICATION)
+public class SentryInterceptor {
+
+    @Inject
+    HttpServerRequest request;
+
+    @AroundInvoke
+    Object intercept(InvocationContext ctx) throws Exception {
+        ITransaction iTransaction = Sentry.startTransaction(request.path(), request.path());
+        Object proceed = ctx.proceed();
+        Log.debug("Intercepted "+request.path()+" "+request.path());
+        iTransaction.finish();
+        return proceed;
+    }
+}


### PR DESCRIPTION
Like the Spring automatic Tracing https://docs.sentry.io/platforms/java/guides/spring-boot/tracing/instrumentation/automatic-instrumentation/, i would implement a Feature which creates Tracing for every Request.  (Later on also maybe JDBC requests). 

In This pull Request, i want to collect Ideas on which Data to add to the Span, and also clarifiy, if its a good idea to include this Feature in this Project. Currently the Implementation is merely a Proof of Concept. 

Currenly missing at least: 


- Tests
- Documentation
- ConfigurationSettings 
- Statustracking of Request to propagate to sentry


