### PR TITLE
Enable structured logging option in Sentry configuration

### DIFF
--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
@@ -25,7 +25,8 @@ public interface SentryConfig {
     boolean enabled();
 
     /**
-     * Determine whether to enable the Sentry detailed structured logging, linked to errors and traces, for debugging and investigation.
+     * Determine whether to enable the Sentry detailed structured logging, linked to errors and traces, for debugging and
+     * investigation.
      * Structured logs allow you to send, view and query logs and parameters sent from your applications within Sentry.
      */
     @WithDefault("false")

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
@@ -25,6 +25,13 @@ public interface SentryConfig {
     boolean enabled();
 
     /**
+     * Determine whether to enable the Sentry detailed structured logging, linked to errors and traces, for debugging and investigation.
+     * Structured logs allow you to send, view and query logs and parameters sent from your applications within Sentry.
+     */
+    @WithDefault("false")
+    boolean logEnabled();
+
+    /**
      * Sentry DSN
      * <p>
      * The DSN is the first and most important thing to configure because it tells the SDK where to send events. You can find

--- a/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
+++ b/runtime/src/main/java/io/quarkus/logging/sentry/SentryHandlerValueFactory.java
@@ -90,6 +90,7 @@ public class SentryHandlerValueFactory {
         }
 
         options.setDsn(sentryConfig.dsn().get());
+        options.getLogs().setEnabled(sentryConfig.logEnabled());
         sentryConfig.environment().ifPresent(options::setEnvironment);
         sentryConfig.release().ifPresent(options::setRelease);
         sentryConfig.ignoredErrors().ifPresent(options::setIgnoredErrors);


### PR DESCRIPTION
This pull request adds support for enabling Sentry Structured Logging through the Quarkus Sentry extension configuration.

Sentry's structured logging feature allows logs to be sent directly to Sentry, where they can be correlated with errors and traces, improving debugging and investigation workflows.

See: #400 